### PR TITLE
`ImRound` and `ImRound64` misuse and resolve dependency on GMod `math.Round`

### DIFF
--- a/lua/imgui.lua
+++ b/lua/imgui.lua
@@ -6042,7 +6042,7 @@ function CalcNextScrollFromScrollTargetAndClamp(window)
 
             scroll[axis] = scroll_target - center_ratio * (window.SizeFull[axis] - decoration_size[axis])
         end
-        scroll[axis] = ImRound(ImMax(scroll[axis], 0.0))
+        scroll[axis] = ImRound64(ImMax(scroll[axis], 0.0))
         if not window.Collapsed and not window.SkipItems then
             scroll[axis] = ImMin(scroll[axis], window.ScrollMax[axis])
         end

--- a/lua/imgui_internal.lua
+++ b/lua/imgui_internal.lua
@@ -47,7 +47,8 @@ ImMax = math.max
 --- @nodiscard
 function ImMaxVec2(a, b) return ImVec2(ImMax(a.x, b.x), ImMax(a.y, b.y)) end
 
-ImRound = math.Round
+ImRound64 = function(val) return math.floor(val + 0.5) end -- FIXME: Positive values only
+
 ImCeil  = math.ceil
 ImSin   = math.sin
 ImCos   = math.cos


### PR DESCRIPTION
`ImRound()` -> `ImRound64()` & resolve dependency